### PR TITLE
ChatTwo集成

### DIFF
--- a/MareSynchronos/Interop/Ipc/IpcCallerChatTwo.cs
+++ b/MareSynchronos/Interop/Ipc/IpcCallerChatTwo.cs
@@ -1,9 +1,11 @@
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
 using Microsoft.Extensions.Logging;
+using MareSynchronos.API.Data;
 using MareSynchronos.API.Dto.Group;
 using MareSynchronos.MareConfiguration;
 using MareSynchronos.PlayerData.Pairs;
+using MareSynchronos.Services.Mediator;
 using MareSynchronos.WebAPI;
 
 namespace MareSynchronos.Interop.Ipc;
@@ -15,6 +17,8 @@ public class IpcCallerChatTwo
 
     private ICallGateSubscriber<int, string, string, DateTime, object?>? _marePush;
     private ICallGateSubscriber<(int major, int minor)>? _chatTwoApiVersion;
+    private ICallGateSubscriber<object?>? _mareChannelsUpdated;
+    private System.Timers.Timer? _notifyTimer;
     
     // ChatTwo <-> Mare chat IPC providers
     private ICallGateProvider<Dictionary<int, string>>? _mareChatChannelInfos;
@@ -37,11 +41,16 @@ public class IpcCallerChatTwo
             _chatTwoApiVersion ??= _pi.GetIpcSubscriber<(int, int)>("ChatTwo.ApiVersion");
             var version = _chatTwoApiVersion.InvokeFunc();
             APIAvailable = version.Item1 == 1 && version.Item2 >= 0;
+            if (APIAvailable)
+            {
+                _mareChannelsUpdated = _pi.GetIpcSubscriber<object?>("ChatTwo.Mare.ChannelInfosUpdated");
+            }
         }
         catch
         {
             APIAvailable = false;
             _marePush = null;
+            _mareChannelsUpdated = null;
         }
     }
 
@@ -65,6 +74,9 @@ public class IpcCallerChatTwo
     {
         try
         {
+            // Ensure current ChatTwo API status
+            CheckAPI();
+
             // Provide ChatTwo IPC endpoints for Mare syncshell chat integration
             _mareChatChannelInfos = _pi.GetIpcProvider<Dictionary<int, string>>("MareChat.ChannelInfos");
             _mareChatChannelInfos.RegisterFunc(() => GetMareChatChannelInfos(mareConfigService, pairManager));
@@ -73,6 +85,13 @@ public class IpcCallerChatTwo
             _mareChatSendMessage.RegisterAction((index, message) => HandleMareChatSendMessage(index, message, mareConfigService, apiController));
             
             _logger.LogInformation("ChatTwo IPC providers registered successfully");
+
+            // Subscribe to runtime join/leave events to notify ChatTwo immediately
+            pairManager.Mediator.Subscribe<JoinedGroupsChangedMessage>(pairManager, _ => NotifyChatTwoChannelInfosUpdated());
+
+            // Also refresh on general UI refresh (e.g., groups/aliases loaded), debounced
+            pairManager.Mediator.Subscribe<RefreshUiMessage>(pairManager, _ => ScheduleNotify());
+            pairManager.Mediator.Subscribe<ConnectedMessage>(pairManager, _ => ScheduleNotify());
         }
         catch (Exception ex)
         {
@@ -87,14 +106,53 @@ public class IpcCallerChatTwo
     {
         try
         {
+            // Notify ChatTwo to clear stale channels before unregistering
+            NotifyChatTwoChannelInfosUpdated();
+
             _mareChatChannelInfos?.UnregisterFunc();
             _mareChatSendMessage?.UnregisterAction();
+            _mareChannelsUpdated = null;
+            _notifyTimer?.Stop();
+            _notifyTimer?.Dispose();
+            _notifyTimer = null;
             _logger.LogDebug("ChatTwo IPC providers unregistered");
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to unregister ChatTwo IPC providers");
         }
+    }
+
+    private void NotifyChatTwoChannelInfosUpdated()
+    {
+        if (!APIAvailable || _mareChannelsUpdated == null) return;
+        try
+        {
+            _mareChannelsUpdated.InvokeAction();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to notify ChatTwo about Mare channel infos update");
+        }
+    }
+
+    private void ScheduleNotify()
+    {
+        if (!APIAvailable || _mareChannelsUpdated == null) return;
+        _notifyTimer ??= new System.Timers.Timer(800) { AutoReset = false };
+        _notifyTimer.Stop();
+        _notifyTimer.Elapsed -= OnNotifyTimerElapsed;
+        _notifyTimer.Elapsed += OnNotifyTimerElapsed;
+        _notifyTimer.Start();
+    }
+
+    private void OnNotifyTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
+    {
+        try
+        {
+            NotifyChatTwoChannelInfosUpdated();
+        }
+        catch { }
     }
 
     /// <summary>
@@ -105,13 +163,14 @@ public class IpcCallerChatTwo
         try
         {
             var result = new Dictionary<int, string>();
-            var auto = mareConfigService.Current.AutoJoinChats;
-            if (auto == null || auto.Count == 0) return result;
+            // Prefer runtime joined groups over config
+            var joined = MareSynchronos.UI.ChatUi.JoinedGroups;
+            if (joined == null || joined.Count == 0) return result;
 
-            // Map first 8 AutoJoinChats entries to indices 0..7
-            for (int i = 0; i < Math.Min(8, auto.Count); i++)
+            // Map first 8 joined groups to indices 0..7
+            for (int i = 0; i < Math.Min(8, joined.Count); i++)
             {
-                var gid = auto[i];
+                var gid = joined[i];
                 // Try resolve a friendly name
                 var friendly = gid;
                 try
@@ -144,12 +203,12 @@ public class IpcCallerChatTwo
         try
         {
             if (string.IsNullOrWhiteSpace(message)) return;
-            var auto = mareConfigService.Current.AutoJoinChats;
-            if (auto == null || index < 0 || index >= auto.Count) return;
-            var gid = auto[index];
+            var joined = MareSynchronos.UI.ChatUi.JoinedGroups;
+            if (joined == null || index < 0 || index >= joined.Count) return;
+            var gid = joined[index];
             if (string.IsNullOrEmpty(gid)) return;
 
-            var dto = new GroupChatDto(new API.Data.UserData(apiController.UID), new API.Data.GroupData(gid), DateTime.UtcNow, message);
+            var dto = new GroupChatDto(new UserData(apiController.UID), new GroupData(gid), DateTime.UtcNow, message);
             _ = apiController.GroupChatServer(dto);
         }
         catch (Exception e)
@@ -167,10 +226,10 @@ public class IpcCallerChatTwo
         
         try
         {
-            var auto = mareConfigService.Current.AutoJoinChats;
-            if (auto == null) return;
+            var joined = MareSynchronos.UI.ChatUi.JoinedGroups;
+            if (joined == null) return;
             
-            var idx = Math.Max(0, auto.FindIndex(g => string.Equals(g, gid, StringComparison.Ordinal)));
+            var idx = Math.Max(0, joined.FindIndex(g => string.Equals(g, gid, StringComparison.Ordinal)));
             if (idx > 7) idx = 7;
 
             _marePush.InvokeAction(idx, sender, message, time);

--- a/MareSynchronos/Interop/Ipc/IpcCallerChatTwo.cs
+++ b/MareSynchronos/Interop/Ipc/IpcCallerChatTwo.cs
@@ -10,7 +10,7 @@ using MareSynchronos.WebAPI;
 
 namespace MareSynchronos.Interop.Ipc;
 
-public class IpcCallerChatTwo
+public class IpcCallerChatTwo : IMediatorSubscriber
 {
     private readonly ILogger<IpcCallerChatTwo> _logger;
     private readonly IDalamudPluginInterface _pi;
@@ -20,9 +20,12 @@ public class IpcCallerChatTwo
     private ICallGateSubscriber<object?>? _mareChannelsUpdated;
     private System.Timers.Timer? _notifyTimer;
     
-    // ChatTwo <-> Mare chat IPC providers
     private ICallGateProvider<Dictionary<int, string>>? _mareChatChannelInfos;
     private ICallGateProvider<int, string, object?>? _mareChatSendMessage;
+
+    // Cached dependencies
+    private PairManager? _pairManager;
+    private ApiController? _apiController;
 
     public IpcCallerChatTwo(ILogger<IpcCallerChatTwo> logger, IDalamudPluginInterface pi)
     {
@@ -31,6 +34,7 @@ public class IpcCallerChatTwo
     }
 
     public bool APIAvailable { get; private set; }
+    public MareMediator Mediator => _pairManager?.Mediator ?? throw new InvalidOperationException("ChatTwo not initialized");
 
     public void CheckAPI()
     {
@@ -67,31 +71,31 @@ public class IpcCallerChatTwo
         }
     }
 
-    /// <summary>
-    /// 注册ChatTwo相关的IPC提供者端点
-    /// </summary>
-    public void RegisterProviders(MareConfigService mareConfigService, PairManager pairManager, ApiController apiController)
+    public void Initialize(MareConfigService mareConfigService, PairManager pairManager, ApiController apiController)
+    {
+        _pairManager ??= pairManager;
+        _apiController ??= apiController;
+    }
+
+    public void RegisterProviders()
     {
         try
         {
-            // Ensure current ChatTwo API status
+            if (_pairManager == null || _apiController == null)
+            {
+                throw new InvalidOperationException("ChatTwo not initialized");
+            }
             CheckAPI();
-
-            // Provide ChatTwo IPC endpoints for Mare syncshell chat integration
             _mareChatChannelInfos = _pi.GetIpcProvider<Dictionary<int, string>>("MareChat.ChannelInfos");
-            _mareChatChannelInfos.RegisterFunc(() => GetMareChatChannelInfos(mareConfigService, pairManager));
-            
+            _mareChatChannelInfos.RegisterFunc(GetMareChatChannelInfos);
+
             _mareChatSendMessage = _pi.GetIpcProvider<int, string, object?>("MareChat.SendMessage");
-            _mareChatSendMessage.RegisterAction((index, message) => HandleMareChatSendMessage(index, message, mareConfigService, apiController));
-            
+            _mareChatSendMessage.RegisterAction(HandleMareChatSendMessage);
+
             _logger.LogInformation("ChatTwo IPC providers registered successfully");
-
-            // Subscribe to runtime join/leave events to notify ChatTwo immediately
-            pairManager.Mediator.Subscribe<JoinedGroupsChangedMessage>(pairManager, _ => NotifyChatTwoChannelInfosUpdated());
-
-            // Also refresh on general UI refresh (e.g., groups/aliases loaded), debounced
-            pairManager.Mediator.Subscribe<RefreshUiMessage>(pairManager, _ => ScheduleNotify());
-            pairManager.Mediator.Subscribe<ConnectedMessage>(pairManager, _ => ScheduleNotify());
+            Mediator.Subscribe<JoinedGroupsChangedMessage>(this, _ => NotifyChatTwoChannelInfosUpdated());
+            Mediator.Subscribe<RefreshUiMessage>(this, _ => ScheduleNotify());
+            Mediator.Subscribe<ConnectedMessage>(this, _ => ScheduleNotify());
         }
         catch (Exception ex)
         {
@@ -99,14 +103,10 @@ public class IpcCallerChatTwo
         }
     }
 
-    /// <summary>
-    /// 注销ChatTwo相关的IPC提供者端点
-    /// </summary>
     public void UnregisterProviders()
     {
         try
         {
-            // Notify ChatTwo to clear stale channels before unregistering
             NotifyChatTwoChannelInfosUpdated();
 
             _mareChatChannelInfos?.UnregisterFunc();
@@ -115,6 +115,10 @@ public class IpcCallerChatTwo
             _notifyTimer?.Stop();
             _notifyTimer?.Dispose();
             _notifyTimer = null;
+            if (_pairManager != null)
+            {
+                try { Mediator.UnsubscribeAll(this); } catch { /* mediator may be disposed */ }
+            }
             _logger.LogDebug("ChatTwo IPC providers unregistered");
         }
         catch (Exception ex)
@@ -152,37 +156,26 @@ public class IpcCallerChatTwo
         {
             NotifyChatTwoChannelInfosUpdated();
         }
-        catch { }
+        catch { /* ignore timer callback errors */ }
     }
 
-    /// <summary>
-    /// 获取Mare聊天频道信息，映射到ChatTwo的频道索引
-    /// </summary>
-    private Dictionary<int, string> GetMareChatChannelInfos(MareConfigService mareConfigService, PairManager pairManager)
+    private Dictionary<int, string> GetMareChatChannelInfos()
     {
         try
         {
             var result = new Dictionary<int, string>();
-            // Prefer runtime joined groups over config
             var joined = MareSynchronos.UI.ChatUi.JoinedGroups;
             if (joined == null || joined.Count == 0) return result;
-
-            // Map first 8 joined groups to indices 0..7
             for (int i = 0; i < Math.Min(8, joined.Count); i++)
             {
                 var gid = joined[i];
-                // Try resolve a friendly name
                 var friendly = gid;
                 try
                 {
-                    // Look up group alias if available
-                    var group = pairManager.Groups.Keys.FirstOrDefault(g => string.Equals(g.GID, gid, StringComparison.Ordinal));
-                    if (group != null)
-                    {
-                        friendly = pairManager.Groups[group].GroupAliasOrGID;
-                    }
+                    var group = _pairManager!.Groups.Keys.FirstOrDefault(g => string.Equals(g.GID, gid, StringComparison.Ordinal));
+                    if (group != null) friendly = _pairManager.Groups[group].GroupAliasOrGID;
                 }
-                catch { /* ignore */ }
+                catch { /* ignore resolve errors */ }
 
                 result[i] = friendly;
             }
@@ -195,10 +188,7 @@ public class IpcCallerChatTwo
         }
     }
 
-    /// <summary>
-    /// 处理从ChatTwo发送到Mare的聊天消息
-    /// </summary>
-    private void HandleMareChatSendMessage(int index, string message, MareConfigService mareConfigService, ApiController apiController)
+    private void HandleMareChatSendMessage(int index, string message)
     {
         try
         {
@@ -208,8 +198,8 @@ public class IpcCallerChatTwo
             var gid = joined[index];
             if (string.IsNullOrEmpty(gid)) return;
 
-            var dto = new GroupChatDto(new UserData(apiController.UID), new GroupData(gid), DateTime.UtcNow, message);
-            _ = apiController.GroupChatServer(dto);
+            var dto = new GroupChatDto(new UserData(_apiController!.UID), new GroupData(gid), DateTime.UtcNow, message);
+            _ = _apiController.GroupChatServer(dto);
         }
         catch (Exception e)
         {
@@ -217,11 +207,9 @@ public class IpcCallerChatTwo
         }
     }
 
-    /// <summary>
-    /// 推送群聊消息到ChatTwo
-    /// </summary>
     public void PushGroupChatMessage(string gid, string sender, string message, DateTime time, MareConfigService mareConfigService)
     {
+        _ = mareConfigService;
         if (!APIAvailable || _marePush == null) return;
         
         try

--- a/MareSynchronos/Interop/Ipc/IpcCallerChatTwo.cs
+++ b/MareSynchronos/Interop/Ipc/IpcCallerChatTwo.cs
@@ -1,0 +1,186 @@
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Microsoft.Extensions.Logging;
+using MareSynchronos.API.Dto.Group;
+using MareSynchronos.MareConfiguration;
+using MareSynchronos.PlayerData.Pairs;
+using MareSynchronos.WebAPI;
+
+namespace MareSynchronos.Interop.Ipc;
+
+public class IpcCallerChatTwo
+{
+    private readonly ILogger<IpcCallerChatTwo> _logger;
+    private readonly IDalamudPluginInterface _pi;
+
+    private ICallGateSubscriber<int, string, string, DateTime, object?>? _marePush;
+    private ICallGateSubscriber<(int major, int minor)>? _chatTwoApiVersion;
+    
+    // ChatTwo <-> Mare chat IPC providers
+    private ICallGateProvider<Dictionary<int, string>>? _mareChatChannelInfos;
+    private ICallGateProvider<int, string, object?>? _mareChatSendMessage;
+
+    public IpcCallerChatTwo(ILogger<IpcCallerChatTwo> logger, IDalamudPluginInterface pi)
+    {
+        _logger = logger;
+        _pi = pi;
+    }
+
+    public bool APIAvailable { get; private set; }
+
+    public void CheckAPI()
+    {
+        try
+        {
+            _marePush = _pi.GetIpcSubscriber<int, string, string, DateTime, object?>("ChatTwo.Mare.Push");
+
+            _chatTwoApiVersion ??= _pi.GetIpcSubscriber<(int, int)>("ChatTwo.ApiVersion");
+            var version = _chatTwoApiVersion.InvokeFunc();
+            APIAvailable = version.Item1 == 1 && version.Item2 >= 0;
+        }
+        catch
+        {
+            APIAvailable = false;
+            _marePush = null;
+        }
+    }
+
+    public void PushMareMessage(int index, string sender, string content, DateTime timeUtc)
+    {
+        if (!APIAvailable || _marePush == null) return;
+        try
+        {
+            _marePush.InvokeAction(index, sender, content, timeUtc);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to push Mare message to ChatTwo");
+        }
+    }
+
+    /// <summary>
+    /// 注册ChatTwo相关的IPC提供者端点
+    /// </summary>
+    public void RegisterProviders(MareConfigService mareConfigService, PairManager pairManager, ApiController apiController)
+    {
+        try
+        {
+            // Provide ChatTwo IPC endpoints for Mare syncshell chat integration
+            _mareChatChannelInfos = _pi.GetIpcProvider<Dictionary<int, string>>("MareChat.ChannelInfos");
+            _mareChatChannelInfos.RegisterFunc(() => GetMareChatChannelInfos(mareConfigService, pairManager));
+            
+            _mareChatSendMessage = _pi.GetIpcProvider<int, string, object?>("MareChat.SendMessage");
+            _mareChatSendMessage.RegisterAction((index, message) => HandleMareChatSendMessage(index, message, mareConfigService, apiController));
+            
+            _logger.LogInformation("ChatTwo IPC providers registered successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to register ChatTwo IPC providers");
+        }
+    }
+
+    /// <summary>
+    /// 注销ChatTwo相关的IPC提供者端点
+    /// </summary>
+    public void UnregisterProviders()
+    {
+        try
+        {
+            _mareChatChannelInfos?.UnregisterFunc();
+            _mareChatSendMessage?.UnregisterAction();
+            _logger.LogDebug("ChatTwo IPC providers unregistered");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to unregister ChatTwo IPC providers");
+        }
+    }
+
+    /// <summary>
+    /// 获取Mare聊天频道信息，映射到ChatTwo的频道索引
+    /// </summary>
+    private Dictionary<int, string> GetMareChatChannelInfos(MareConfigService mareConfigService, PairManager pairManager)
+    {
+        try
+        {
+            var result = new Dictionary<int, string>();
+            var auto = mareConfigService.Current.AutoJoinChats;
+            if (auto == null || auto.Count == 0) return result;
+
+            // Map first 8 AutoJoinChats entries to indices 0..7
+            for (int i = 0; i < Math.Min(8, auto.Count); i++)
+            {
+                var gid = auto[i];
+                // Try resolve a friendly name
+                var friendly = gid;
+                try
+                {
+                    // Look up group alias if available
+                    var group = pairManager.Groups.Keys.FirstOrDefault(g => string.Equals(g.GID, gid, StringComparison.Ordinal));
+                    if (group != null)
+                    {
+                        friendly = pairManager.Groups[group].GroupAliasOrGID;
+                    }
+                }
+                catch { /* ignore */ }
+
+                result[i] = friendly;
+            }
+            return result;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error building MareChat.ChannelInfos");
+            return new Dictionary<int, string>();
+        }
+    }
+
+    /// <summary>
+    /// 处理从ChatTwo发送到Mare的聊天消息
+    /// </summary>
+    private void HandleMareChatSendMessage(int index, string message, MareConfigService mareConfigService, ApiController apiController)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(message)) return;
+            var auto = mareConfigService.Current.AutoJoinChats;
+            if (auto == null || index < 0 || index >= auto.Count) return;
+            var gid = auto[index];
+            if (string.IsNullOrEmpty(gid)) return;
+
+            var dto = new GroupChatDto(new API.Data.UserData(apiController.UID), new API.Data.GroupData(gid), DateTime.UtcNow, message);
+            _ = apiController.GroupChatServer(dto);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error handling MareChat.SendMessage for index {index}", index);
+        }
+    }
+
+    /// <summary>
+    /// 推送群聊消息到ChatTwo
+    /// </summary>
+    public void PushGroupChatMessage(string gid, string sender, string message, DateTime time, MareConfigService mareConfigService)
+    {
+        if (!APIAvailable || _marePush == null) return;
+        
+        try
+        {
+            var auto = mareConfigService.Current.AutoJoinChats;
+            if (auto == null) return;
+            
+            var idx = Math.Max(0, auto.FindIndex(g => string.Equals(g, gid, StringComparison.Ordinal)));
+            if (idx > 7) idx = 7;
+
+            _marePush.InvokeAction(idx, sender, message, time);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to push group chat message to ChatTwo");
+        }
+    }
+}
+
+
+

--- a/MareSynchronos/Interop/Ipc/IpcManager.cs
+++ b/MareSynchronos/Interop/Ipc/IpcManager.cs
@@ -7,7 +7,8 @@ public sealed partial class IpcManager : DisposableMediatorSubscriberBase
 {
     public IpcManager(ILogger<IpcManager> logger, MareMediator mediator,
         IpcCallerPenumbra penumbraIpc, IpcCallerGlamourer glamourerIpc, IpcCallerCustomize customizeIpc, IpcCallerHeels heelsIpc,
-        IpcCallerHonorific honorificIpc, IpcCallerMoodles moodlesIpc, IpcCallerPetNames ipcCallerPetNames, IpcCallerBrio ipcCallerBrio) : base(logger, mediator)
+        IpcCallerHonorific honorificIpc, IpcCallerMoodles moodlesIpc, IpcCallerPetNames ipcCallerPetNames, IpcCallerBrio ipcCallerBrio,
+        IpcCallerChatTwo chatTwoIpc) : base(logger, mediator)
     {
         CustomizePlus = customizeIpc;
         Heels = heelsIpc;
@@ -17,6 +18,7 @@ public sealed partial class IpcManager : DisposableMediatorSubscriberBase
         Moodles = moodlesIpc;
         PetNames = ipcCallerPetNames;
         Brio = ipcCallerBrio;
+        ChatTwo = chatTwoIpc;
 
         if (Initialized)
         {
@@ -46,6 +48,7 @@ public sealed partial class IpcManager : DisposableMediatorSubscriberBase
     public IpcCallerPetNames PetNames { get; }
 
     public IpcCallerBrio Brio { get; }
+    public IpcCallerChatTwo ChatTwo { get; }
 
     private void PeriodicApiStateCheck()
     {
@@ -58,5 +61,6 @@ public sealed partial class IpcManager : DisposableMediatorSubscriberBase
         Moodles.CheckAPI();
         PetNames.CheckAPI();
         Brio.CheckAPI();
+        ChatTwo.CheckAPI();
     }
 }

--- a/MareSynchronos/Interop/Ipc/IpcProvider.cs
+++ b/MareSynchronos/Interop/Ipc/IpcProvider.cs
@@ -1,11 +1,14 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
+using MareSynchronos.API.Dto.Group;
 using MareSynchronos.API.Dto.User;
+using MareSynchronos.MareConfiguration;
 using MareSynchronos.PlayerData.Handlers;
 using MareSynchronos.PlayerData.Pairs;
 using MareSynchronos.Services;
 using MareSynchronos.Services.Mediator;
+using MareSynchronos.WebAPI;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -25,17 +28,28 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
     private ICallGateProvider<string, string, string, object?>? _applyStatusesToPairRequest;
     private ICallGateProvider<int, string, object?>? _moodlesShare;
 
+
+
+        private readonly ApiController _apiController;
+        private readonly MareConfigService _mareConfigService;
+        private readonly IpcCallerChatTwo _chatTwoIpc;
+
     public MareMediator Mediator { get; init; }
 
     public IpcProvider(ILogger<IpcProvider> logger, IDalamudPluginInterface pi,
         DalamudUtilService dalamudUtil, PairManager  pairManager,
-        CharaDataManager charaDataManager, MareMediator mareMediator)
+        CharaDataManager charaDataManager, MareMediator mareMediator,
+        ApiController apiController, MareConfigService mareConfigService,
+        IpcCallerChatTwo chatTwoIpc)
     {
         _logger = logger;
         _pi = pi;
         _charaDataManager = charaDataManager;
         Mediator = mareMediator;
         _pairManager = pairManager;
+        _apiController = apiController;
+        _mareConfigService = mareConfigService;
+        _chatTwoIpc = chatTwoIpc;
 
         Mediator.Subscribe<GameObjectHandlerCreatedMessage>(this, (msg) =>
         {
@@ -64,6 +78,9 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
         _moodlesShare = _pi.GetIpcProvider<int, string, object?>("MareSynchronos.MoodlesShare");
         _moodlesShare.RegisterAction(ShareMoodles);
 
+        // Register ChatTwo IPC providers
+        _chatTwoIpc.RegisterProviders(_mareConfigService, _pairManager, _apiController);
+
         _logger.LogInformation("Started IpcProviderService");
         return Task.CompletedTask;
     }
@@ -81,6 +98,10 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
         _loadFileAsyncProvider?.UnregisterFunc();
         _handledGameAddresses?.UnregisterFunc();
         _applyStatusesToPairRequest?.UnregisterAction();
+
+        // Unregister ChatTwo IPC providers
+        _chatTwoIpc.UnregisterProviders();
+
         Mediator.UnsubscribeAll(this);
         return Task.CompletedTask;
     }
@@ -110,6 +131,8 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
     {
         return _activeGameObjectHandlers.Where(g => g.Address != nint.Zero).Select(g => g.Address).Distinct().ToList();
     }
+
+
 
         /// <summary>
     /// Handles the request from our clients moodles plugin to update another one of our pairs status.

--- a/MareSynchronos/Interop/Ipc/IpcProvider.cs
+++ b/MareSynchronos/Interop/Ipc/IpcProvider.cs
@@ -28,11 +28,7 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
     private ICallGateProvider<string, string, string, object?>? _applyStatusesToPairRequest;
     private ICallGateProvider<int, string, object?>? _moodlesShare;
 
-
-
-        private readonly ApiController _apiController;
-        private readonly MareConfigService _mareConfigService;
-        private readonly IpcCallerChatTwo _chatTwoIpc;
+    private readonly IpcCallerChatTwo _chatTwoIpc;
 
     public MareMediator Mediator { get; init; }
 
@@ -47,9 +43,9 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
         _charaDataManager = charaDataManager;
         Mediator = mareMediator;
         _pairManager = pairManager;
-        _apiController = apiController;
-        _mareConfigService = mareConfigService;
         _chatTwoIpc = chatTwoIpc;
+        // Initialize ChatTwo dependencies without retaining references here
+        _chatTwoIpc.Initialize(mareConfigService, _pairManager, apiController);
 
         Mediator.Subscribe<GameObjectHandlerCreatedMessage>(this, (msg) =>
         {
@@ -79,7 +75,7 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
         _moodlesShare.RegisterAction(ShareMoodles);
 
         // Register ChatTwo IPC providers
-        _chatTwoIpc.RegisterProviders(_mareConfigService, _pairManager, _apiController);
+        _chatTwoIpc.RegisterProviders();
 
         _logger.LogInformation("Started IpcProviderService");
         return Task.CompletedTask;
@@ -131,8 +127,6 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
     {
         return _activeGameObjectHandlers.Where(g => g.Address != nint.Zero).Select(g => g.Address).Distinct().ToList();
     }
-
-
 
         /// <summary>
     /// Handles the request from our clients moodles plugin to update another one of our pairs status.

--- a/MareSynchronos/Plugin.cs
+++ b/MareSynchronos/Plugin.cs
@@ -128,7 +128,9 @@ public sealed class Plugin : IDalamudPlugin
             collection.AddSingleton((s) => new IpcProvider(s.GetRequiredService<ILogger<IpcProvider>>(),
                 pluginInterface,
                  s.GetRequiredService<DalamudUtilService>(), s.GetRequiredService<PairManager>(),
-                s.GetRequiredService<CharaDataManager>(), s.GetRequiredService<MareMediator>()));
+                s.GetRequiredService<CharaDataManager>(), s.GetRequiredService<MareMediator>(),
+                s.GetRequiredService<ApiController>(), s.GetRequiredService<MareConfigService>(),
+                s.GetRequiredService<IpcCallerChatTwo>()));
             collection.AddSingleton<SelectPairForTagUi>();
             collection.AddSingleton((s) => new EventAggregator(pluginInterface.ConfigDirectory.FullName,
                 s.GetRequiredService<ILogger<EventAggregator>>(), s.GetRequiredService<MareMediator>()));
@@ -156,10 +158,12 @@ public sealed class Plugin : IDalamudPlugin
                 s.GetRequiredService<DalamudUtilService>(), s.GetRequiredService<MareMediator>()));
             collection.AddSingleton((s) => new IpcCallerBrio(s.GetRequiredService<ILogger<IpcCallerBrio>>(), pluginInterface,
                 s.GetRequiredService<DalamudUtilService>()));
+            collection.AddSingleton((s) => new IpcCallerChatTwo(s.GetRequiredService<ILogger<IpcCallerChatTwo>>(), pluginInterface));
             collection.AddSingleton((s) => new IpcManager(s.GetRequiredService<ILogger<IpcManager>>(),
                 s.GetRequiredService<MareMediator>(), s.GetRequiredService<IpcCallerPenumbra>(), s.GetRequiredService<IpcCallerGlamourer>(),
                 s.GetRequiredService<IpcCallerCustomize>(), s.GetRequiredService<IpcCallerHeels>(), s.GetRequiredService<IpcCallerHonorific>(),
-                s.GetRequiredService<IpcCallerMoodles>(), s.GetRequiredService<IpcCallerPetNames>(), s.GetRequiredService<IpcCallerBrio>()));
+                s.GetRequiredService<IpcCallerMoodles>(), s.GetRequiredService<IpcCallerPetNames>(), s.GetRequiredService<IpcCallerBrio>(),
+                s.GetRequiredService<IpcCallerChatTwo>()));
             collection.AddSingleton((s) => new NotificationService(s.GetRequiredService<ILogger<NotificationService>>(),
                 s.GetRequiredService<MareMediator>(), s.GetRequiredService<DalamudUtilService>(),
                 notificationManager, chatGui, s.GetRequiredService<MareConfigService>()));

--- a/MareSynchronos/Services/Mediator/Messages.cs
+++ b/MareSynchronos/Services/Mediator/Messages.cs
@@ -73,6 +73,7 @@ public record CompactUiChange(Vector2 Size, Vector2 Position) : MessageBase;
 public record ProfileOpenStandaloneMessage(Pair Pair) : MessageBase;
 public record RemoveWindowMessage(WindowMediatorSubscriberBase Window) : MessageBase;
 public record RefreshUiMessage : MessageBase;
+public record JoinedGroupsChangedMessage : MessageBase;
 public record OpenReportPopupMessage(Pair PairToReport) : MessageBase;
 public record OpenBanUserPopupMessage(Pair PairToBan, GroupFullInfoDto GroupFullInfoDto) : MessageBase;
 public record OpenCensusPopupMessage() : MessageBase;

--- a/MareSynchronos/UI/CharaDataHubUi.McdOnline.cs
+++ b/MareSynchronos/UI/CharaDataHubUi.McdOnline.cs
@@ -172,7 +172,7 @@ internal sealed partial class CharaDataHubUi
 
         UiSharedService.ScaledNextItemWidth(200);
         var dtoShareType = updateDto.ShareType;
-        if (ImGui.BeginCombo("Sharing", GetShareTypeString(dtoShareType)))
+        if (ImGui.BeginCombo("共享类型", GetShareTypeString(dtoShareType)))
         {
             foreach (var shareType in Enum.GetValues(typeof(ShareTypeDto)).Cast<ShareTypeDto>())
             {
@@ -567,10 +567,10 @@ internal sealed partial class CharaDataHubUi
     {
         _uiSharedService.BigText("在线MCD");
 
-        DrawHelpFoldout("In this tab you can create, view and edit your own Mare Character Data that is stored on the server." + Environment.NewLine + Environment.NewLine
-            + "Mare Character Data Online functions similar to the previous MCDF standard for exporting your character, except that you do not have to send a file to the other person but solely a code." + Environment.NewLine + Environment.NewLine
-            + "There would be a bit too much to explain here on what you can do here in its entirety, however, all elements in this tab have help texts attached what they are used for. Please review them carefully." + Environment.NewLine + Environment.NewLine
-            + "Be mindful that when you share your Character Data with other people there is a chance that, with the help of unsanctioned 3rd party plugins, your appearance could be stolen irreversibly, just like when using MCDF.");
+        DrawHelpFoldout("在此选项卡中，您可以创建、查看和编辑存储在服务器上的Mare角色数据。" + Environment.NewLine + Environment.NewLine
+            + "Mare在线角色数据的功能类似于之前用于导出角色的MCDF标准，不同之处在于您不必向其他人发送文件，而只需提供一个代码。" + Environment.NewLine + Environment.NewLine
+            + "这里要解释的内容太多，无法完整说明您在此处可以做的所有事情，但是此选项卡中的所有元素都附有帮助文本，说明它们的用途。请仔细查看。" + Environment.NewLine + Environment.NewLine
+            + "请注意，当您与其他人分享角色数据时，借助未经授权的第三方插件，您的外观可能会被不可逆地盗用，就像使用MCDF时一样。");
 
         ImGuiHelpers.ScaledDummy(5);
         using (ImRaii.Disabled((!_charaDataManager.GetAllDataTask?.IsCompleted ?? false)

--- a/MareSynchronos/UI/ChatUi.cs
+++ b/MareSynchronos/UI/ChatUi.cs
@@ -102,6 +102,7 @@ namespace MareSynchronos.UI
                         if (!IsOpen)
                         {
                             JoinedGroups.Remove(group);
+                            Mediator.Publish(new JoinedGroupsChangedMessage());
                             if (_lastActiveGroup == group)
                             {
                                 _lastActiveGroup = null;

--- a/MareSynchronos/UI/ChatUi.cs
+++ b/MareSynchronos/UI/ChatUi.cs
@@ -63,7 +63,8 @@ namespace MareSynchronos.UI
                 _chatLogs.RemoveAt(_chatLogs.FindIndex(x => x.Group == msg.Group));
             }
             _logger.LogDebug($"Received chat message: '{msg.Message}' from {msg.Sender} in group {msg.Group}");
-            if (_mareConfig.Current.PortToChatGui)
+            // 若 ChatTwo 已连接，则不再将聊天输出到默认聊天框，避免重复
+            if (_mareConfig.Current.PortToChatGui && !_uiSharedService.ChatTwoExists)
             {
                 var groupName = _idDisplayHandler
                     .GetGroupText(_pairManager.Groups.First(x => x.Key.GID == msg.Group).Value).text;

--- a/MareSynchronos/UI/Components/DrawFolderGroup.cs
+++ b/MareSynchronos/UI/Components/DrawFolderGroup.cs
@@ -167,6 +167,7 @@ public class DrawFolderGroup : DrawFolderBase
                 if (!ChatUi.JoinedGroups.Contains(_groupFullInfoDto.GID))
                 {
                     ChatUi.JoinedGroups.Add(_groupFullInfoDto.GID);
+                    _mareMediator.Publish(new JoinedGroupsChangedMessage());
                 }
 
                 _mareMediator.Publish(new OpenChatUi());

--- a/MareSynchronos/UI/SettingsUi.cs
+++ b/MareSynchronos/UI/SettingsUi.cs
@@ -1007,10 +1007,17 @@ public class SettingsUi : WindowMediatorSubscriberBase
 
 
         var port = _configService.Current.PortToChatGui;
-        if (ImGui.Checkbox("将聊天输出到游戏聊天框", ref port))
+        using (ImRaii.Disabled(_uiShared.ChatTwoExists))
         {
-            _configService.Current.PortToChatGui = port;
-            _configService.Save();
+            if (ImGui.Checkbox("将聊天输出到游戏聊天框", ref port))
+            {
+                _configService.Current.PortToChatGui = port;
+                _configService.Save();
+            }
+        }
+        if (_uiShared.ChatTwoExists)
+        {
+            UiSharedService.AttachToolTip("已检测到 ChatTwo，聊天将由 ChatTwo 处理，此选项已自动停用以避免重复输出。");
         }
 
         ImGui.Indent();

--- a/MareSynchronos/UI/UISharedService.cs
+++ b/MareSynchronos/UI/UISharedService.cs
@@ -785,7 +785,7 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
         ColorText("Glamourer", GetBoolColor(_glamourerExists));
         AttachToolTip($"Glamourer目前" + (_glamourerExists ? "已为最新." : "未安装或需要更新."));
 
-        ImGui.TextUnformatted("Optional Plugins:");
+        ImGui.TextUnformatted("可选插件：");
         ImGui.SameLine(150);
         ColorText("SimpleHeels", GetBoolColor(_heelsExists));
         AttachToolTip($"SimpleHeels目前" + (_heelsExists ? "已为最新." : "未安装或需要更新."));

--- a/MareSynchronos/UI/UISharedService.cs
+++ b/MareSynchronos/UI/UISharedService.cs
@@ -53,6 +53,7 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
     private readonly ITextureProvider _textureProvider;
     private readonly TokenProvider _tokenProvider;
     private bool _brioExists = false;
+    private bool _chatTwoExists = false;
     private bool _cacheDirectoryHasOtherFilesThanCache = false;
     private bool _cacheDirectoryIsValidPath = true;
     private bool _customizePlusExists = false;
@@ -107,6 +108,7 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
             _moodlesExists = _ipcManager.Moodles.APIAvailable;
             _petNamesExists = _ipcManager.PetNames.APIAvailable;
             _brioExists = _ipcManager.Brio.APIAvailable;
+            _chatTwoExists = _ipcManager.ChatTwo.APIAvailable;
         });
 
         UidFont = _pluginInterface.UiBuilder.FontAtlas.NewDelegateFontHandle(e =>
@@ -137,6 +139,7 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
     public IFontHandle UidFont { get; init; }
     public Dictionary<ushort, string> WorldData => _dalamudUtil.WorldData.Value;
     public uint WorldId => _dalamudUtil.GetHomeWorldId();
+    public bool ChatTwoExists => _chatTwoExists;
 
     public static void AttachToolTip(string text)
     {
@@ -809,6 +812,10 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
         ImGui.SameLine();
         ColorText("Brio", GetBoolColor(_brioExists));
         AttachToolTip($"Brio目前" + (_brioExists ? "已为最新." : "未安装或需要更新."));
+
+        ImGui.SameLine();
+        ColorText("ChatTwo", GetBoolColor(_chatTwoExists));
+        AttachToolTip($"ChatTwo目前" + (_chatTwoExists ? "已为最新." : "未安装或需要更新."));
 
         if (!_penumbraExists || !_glamourerExists)
         {

--- a/MareSynchronos/WebAPI/SignalR/ApiController.Functions.Callbacks.cs
+++ b/MareSynchronos/WebAPI/SignalR/ApiController.Functions.Callbacks.cs
@@ -248,7 +248,25 @@ public partial class ApiController
 
     public Task Client_GroupChat(GroupChatDto groupChatDto)
     {
-        ExecuteSafely(() => Mediator.Publish(new ChatMessage(groupChatDto.User.UID, groupChatDto.GID, groupChatDto.Time, groupChatDto.Message)));
+        ExecuteSafely(() =>
+        {
+            // Mare 内置聊天 UI
+            Mediator.Publish(new ChatMessage(groupChatDto.User.UID, groupChatDto.GID, groupChatDto.Time, groupChatDto.Message));
+
+            // 若 ChatTwo 可用，推送为 MareLinkshell[i]
+            try
+            {
+                var sender = string.Equals(groupChatDto.User.UID, UID, StringComparison.Ordinal)
+                    ? DisplayName
+                    : _pairManager.GetPairByUID(groupChatDto.User.UID)?.UserData.AliasOrUID ?? groupChatDto.User.AliasOrUID;
+
+                _ipcManager.ChatTwo.PushGroupChatMessage(groupChatDto.GID, sender, groupChatDto.Message, groupChatDto.Time, _mareConfigService);
+            }
+            catch
+            {
+                // 忽略 ChatTwo 不存在的情况
+            }
+        });
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
佬帮我瞅瞅O.o

目标：与 [ChatTwo](https://github.com/MeowZWR/ChatTwo/tree/Mare) 建立双向 IPC 集成 
- 在 ChatTwo 中显示同步贝聊天消息，由ChatTwo控制频道过滤和颜色设置，并允许从 ChatTwo 发送消息到Mare的同步贝聊天，由 ChatTwo 将接收到的消息存入数据库。

Mare → ChatTwo
- 推送消息：ChatTwo.Mare.Push(index, sender, content, timeUtc)，将同步贝聊天消息推送到 ChatTwo 指定频道。
- 通知频道变更：ChatTwo.Mare.ChannelInfosUpdated，在加入/退出同步贝聊天、个性ID变化、连接或 UI 刷新时触发。

ChatTwo → Mare
- 读取频道信息：订阅 MareChat.ChannelInfos，获取 index -> 频道名 映射（优先个性ID，否则为 GID），来源 ChatUi.JoinedGroups，最多 8 个。
- 发送群聊：调用 MareChat.SendMessage(index, message)，Mare 转为 GroupChatDto 上行至服务器。

启停与版本
- 启动在 IpcProvider.StartAsync 注册提供者，停止时注销。
- 通过 ChatTwo.ApiVersion 校验是否可用。

UI 与行为
- 检测到 ChatTwo 后，“将聊天输出到游戏聊天框”选项会自动禁用，避免重复输出。
- 仅同步并映射前 8 个已加入的同步贝聊天（索引 0–7），超出部分不会映射。